### PR TITLE
Require Node.js 8, fix map isolation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
-*.js text eol=lf
+* text=auto eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - '12'
+  - '10'
   - '8'
-  - '6'

--- a/index.js
+++ b/index.js
@@ -1,15 +1,9 @@
 'use strict';
 const irregularPlurals = require('./irregular-plurals.json');
 
-const map = new Map();
-// TODO: Use Object.entries when targeting Node.js 8
-for (const key of Object.keys(irregularPlurals)) {
-	map.set(key, irregularPlurals[key]);
-}
-
 // Ensure nobody can modify each others Map
 Object.defineProperty(module, 'exports', {
 	get() {
-		return map;
+		return new Map(Object.entries(irregularPlurals));
 	}
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -33,7 +33,7 @@
 		"nouns"
 	],
 	"devDependencies": {
-		"ava": "*",
-		"xo": "*"
+		"ava": "^1.4.1",
+		"xo": "^0.24.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,17 @@
 import test from 'ava';
-import m from '.';
+import irregularPlurals from '.';
 
 test('main', t => {
-	t.true(m.has('calf'));
+	t.true(irregularPlurals.has('calf'));
+	t.is(irregularPlurals.get('calf'), 'calves');
+});
+
+test('isolated', t => {
+	const fresh1 = require('.');
+	const fresh2 = require('.');
+
+	fresh1.delete('calf');
+	t.false(fresh1.has('calf'));
+	t.true(fresh2.has('calf'));
+	t.true(irregularPlurals.has('calf'));
 });


### PR DESCRIPTION
The `module.exports` getter in previous version had no real effect since it was returning the same map object for each require.  This causes each `require` to get an isolated map object, adds tests to verify this.